### PR TITLE
fix: use environment variable for API URL in Sidebar

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -21,7 +21,7 @@ const Sidebar = ({ open, toggleSidebar }) => {
         setLoadingReports(true);
         setReportError('');
 
-        const response = await fetch('/api/reports/menu');
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/reports/menu`);
         if (!response.ok) {
           throw new Error(`Failed to load report menu: ${response.status}`);
         }


### PR DESCRIPTION
Fetch reports menu from API URL defined in environment variable instead of hardcoded path